### PR TITLE
Feature/query author name

### DIFF
--- a/rd_ui/app/views/query.html
+++ b/rd_ui/app/views/query.html
@@ -94,8 +94,7 @@
             <p>
                 <span class="glyphicon glyphicon-user"></span>
                 <span class="text-muted">Created By </span>
-                <strong ng-hide="isQueryOwner">{{query.user.name}}</strong>
-                <strong ng-show="isQueryOwner">You</strong>
+                <strong ng-show="isQueryOwner">{{query.user.name}}</strong>
             </p>
             <p>
                 <span class="glyphicon glyphicon-play"></span>


### PR DESCRIPTION
Changed it so that if you are viewing a query that you created it will name you as the creator instead of just "you" to keep it consistant with the dashboard.
