### PR TITLE
Feature/sqlparser fix

### DIFF
--- a/redash/utils.py
+++ b/redash/utils.py
@@ -39,7 +39,7 @@ class SQLMetaData(object):
     def extract_table_names(self, tokens):
         tables = set()
         tokens = [t for t in tokens if t.ttype not in (sqlparse.tokens.Whitespace, sqlparse.tokens.Newline)]
-        
+
         for i in range(len(tokens)):
             if tokens[i].is_group():
                 tables.update(self.extract_table_names(tokens[i].tokens))
@@ -50,10 +50,13 @@ class SQLMetaData(object):
 
                     if isinstance(tokens[i + 1], sqlparse.sql.IdentifierList):
                         tables.update(set([t.value for t in tokens[i+1].get_identifiers()]))
-        
+
         result = []
         for table in tables:
             if table:
+                # This will match the first word in the string which should be a table name
+                # sqlparser recursivenes returns multiple results including whole subqueries and their tablenames as well
+                # we only want the table names and shoud ignore anything else
                 res = re.search("^[a-zA-Z0-9_]*",table)
                 tableName = res.group(0)
                 if tableName != "":


### PR DESCRIPTION
Sqlparser is a third party library. It is used in redash to retrieve table names which then are cross referenced with table permissions set in groups table. Due to some complexity in queries, sqlparser was returning both table names and subqueries used. This fix is matching the table names against regular expression which should ignore everything which doe snot look like a table. 
